### PR TITLE
Refactor randomizer checkpoint generation, add logging

### DIFF
--- a/out/data/goal_src/engine/game/collectables.gc
+++ b/out/data/goal_src/engine/game/collectables.gc
@@ -5,56 +5,65 @@
 ;; name in dgo: collectables
 ;; dgos: GAME, ENGINE
 
+
 ;;Randomizer
 ;; cell-interval serves as a counter, it counts up until it is raul to cells-needed-to-warp, then it warps jak and resets itself to count again
-(define-extern *randomizer-settings* randomizer-settings)
 (define *cell-interval* 0.0)
+(define *randomCheckpointName* (the-as string #f))
 (define *randomCheckpoint* (the continue-point #f))
 (define racer? #f) 
 (define flutflut? #f)
 
-
-;;cells-needed-to-warp can be set to any value you would like here, 1.0 will warp every cell 7.0 will warp every 7 cells.
-
-
-
 (defun citadelCheck? ()
 (if 
 (or
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-start"))
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-entrance")) 
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-warp"))
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-launch-start"))
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-launch-end"))
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-plat-start"))
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-plat-end"))
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-generator-start"))
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-generator-end"))
-(= *randomCheckpoint* (get-continue-by-name *game-info* "citadel-elevator"))
+(= *randomCheckpointName* "citadel-start")
+(= *randomCheckpointName* "citadel-entrance")
+(= *randomCheckpointName* "citadel-warp")
+(= *randomCheckpointName* "citadel-launch-start")
+(= *randomCheckpointName* "citadel-launch-end")
+(= *randomCheckpointName* "citadel-plat-start")
+(= *randomCheckpointName* "citadel-plat-end")
+(= *randomCheckpointName* "citadel-generator-start")
+(= *randomCheckpointName* "citadel-generator-end")
+(= *randomCheckpointName* "citadel-elevator")
 )
 (return #t)
 (return #f)
 )
 #f
 )
-(define-extern makeRandomCheckpoint (function none))
 
 
-(defun checkRandomCheckpoint()
-
-(if (and (not (task-closed? (game-task citadel-sage-green) (task-status need-hint))) (citadelCheck?))
-(begin
-(makeRandomCheckpoint)
-)
-)
-(none)
+(defun checkRandomCheckpoint?()
+  ;; returns whether the checkpoint is safe to use
+  (if (and (not (task-closed? (game-task citadel-sage-green) (task-status need-hint))) (citadelCheck?))
+    (return #t)
+    (return #f)
+  )
+  #f
 )
 
 (defun makeRandomCheckpoint()
+  (define foundValid? #f) 
+  (set! *randomCheckpointName* (-> *checkpoint-list* (rand-vu-int-range 0 66)))
+  (while (not foundValid?)
+    (format 0 "RANDOMIZER: validating checkpoint ~A~%" *randomCheckpointName*)
 
-(set! *randomCheckpoint* (get-continue-by-name *game-info* (-> *checkpoint-list* (rand-vu-int-range 0 66))))
-(checkRandomCheckpoint)
-(none)
+    ;; if checkpoint is valid, persist it, otherwise regenerate
+    (if checkRandomCheckpoint?
+      (begin 
+        (format 0 "RANDOMIZER: checkpoint ~A is valid~%" *randomCheckpointName*)
+        (set! *randomCheckpoint* (get-continue-by-name *game-info* *randomCheckpointName*))
+        (set! foundValid? #t) ;; to break from while loop
+      )
+      (begin
+        (format 0 "RANDOMIZER: checkpoint ~A is NOT valid, will generate another~%" *randomCheckpointName*)
+        (set! *randomCheckpointName* (-> *checkpoint-list* (rand-vu-int-range 0 66)))
+      )
+    )
+  )
+  (none)
 )
 ;;End Randomizer settings
 

--- a/out/data/goal_src/engine/game/collectables.gc
+++ b/out/data/goal_src/engine/game/collectables.gc
@@ -1788,7 +1788,9 @@
         (makeRandomCheckpoint)
         (if (>= *cell-interval* (-> *randomizer-settings* cells-needed-to-warp))
           (begin
-            (set! (-> *game-info* current-continue) *randomCheckpoint*)        
+            (format 0 "RANDOMIZER: warping from ~A...~%" (-> *level* level 0 name))
+            (makeRandomCheckpoint)
+            (format 0 "RANDOMIZER: ...warping to ~A~%" *randomCheckpointName*)     
             (start 'play *randomCheckpoint*)
             (set! *cell-interval* 0.0)
           )

--- a/out/data/goal_src/engine/game/collectables.gc
+++ b/out/data/goal_src/engine/game/collectables.gc
@@ -17,16 +17,16 @@
 (defun citadelCheck? ()
 (if 
 (or
-(= *randomCheckpointName* "citadel-start")
-(= *randomCheckpointName* "citadel-entrance")
-(= *randomCheckpointName* "citadel-warp")
-(= *randomCheckpointName* "citadel-launch-start")
-(= *randomCheckpointName* "citadel-launch-end")
-(= *randomCheckpointName* "citadel-plat-start")
-(= *randomCheckpointName* "citadel-plat-end")
-(= *randomCheckpointName* "citadel-generator-start")
-(= *randomCheckpointName* "citadel-generator-end")
-(= *randomCheckpointName* "citadel-elevator")
+(string= *randomCheckpointName* "citadel-start")
+(string= *randomCheckpointName* "citadel-entrance")
+(string= *randomCheckpointName* "citadel-warp")
+(string= *randomCheckpointName* "citadel-launch-start")
+(string= *randomCheckpointName* "citadel-launch-end")
+(string= *randomCheckpointName* "citadel-plat-start")
+(string= *randomCheckpointName* "citadel-plat-end")
+(string= *randomCheckpointName* "citadel-generator-start")
+(string= *randomCheckpointName* "citadel-generator-end")
+(string= *randomCheckpointName* "citadel-elevator")
 )
 (return #t)
 (return #f)
@@ -36,6 +36,7 @@
 
 
 (defun checkRandomCheckpoint?()
+
   ;; returns whether the checkpoint is safe to use
   (if (and (not (task-closed? (game-task citadel-sage-green) (task-status need-hint))) (citadelCheck?))
     (return #f)
@@ -49,9 +50,9 @@
   (set! *randomCheckpointName* (-> *checkpoint-list* (rand-vu-int-range 0 66)))
   (while (not foundValid?)
     (format 0 "RANDOMIZER: validating checkpoint ~A~%" *randomCheckpointName*)
-
+    
     ;; if checkpoint is valid, persist it, otherwise regenerate
-    (if checkRandomCheckpoint?
+    (if (checkRandomCheckpoint?)
       (begin 
         (format 0 "RANDOMIZER: checkpoint ~A is valid~%" *randomCheckpointName*)
         (set! *randomCheckpoint* (get-continue-by-name *game-info* *randomCheckpointName*))

--- a/out/data/goal_src/engine/game/collectables.gc
+++ b/out/data/goal_src/engine/game/collectables.gc
@@ -49,8 +49,6 @@
   (define foundValid? #f) 
   (set! *randomCheckpointName* (-> *checkpoint-list* (rand-vu-int-range 0 66)))
   (while (not foundValid?)
-    (format 0 "RANDOMIZER: validating checkpoint ~A~%" *randomCheckpointName*)
-    
     ;; if checkpoint is valid, persist it, otherwise regenerate
     (if (checkRandomCheckpoint?)
       (begin 

--- a/out/data/goal_src/engine/game/collectables.gc
+++ b/out/data/goal_src/engine/game/collectables.gc
@@ -38,8 +38,8 @@
 (defun checkRandomCheckpoint?()
   ;; returns whether the checkpoint is safe to use
   (if (and (not (task-closed? (game-task citadel-sage-green) (task-status need-hint))) (citadelCheck?))
-    (return #t)
     (return #f)
+    (return #t)
   )
   #f
 )


### PR DESCRIPTION
For #25. Some sample logs:
```
RANDOMIZER: warping from snow...
RANDOMIZER: checkpoint "sunken2" is valid
RANDOMIZER: ...warping to "sunken2"
```
```
RANDOMIZER: warping from maincave...
RANDOMIZER: checkpoint "citadel-launch-start" is NOT valid, will generate another
RANDOMIZER: checkpoint "lavatube-end" is valid
RANDOMIZER: ...warping to "lavatube-end"
```