### PR TITLE
create backup of seed and checkpoints used to regenerate checkpoint list/state

### DIFF
--- a/out/data/goal_src/engine/game/collectables.gc
+++ b/out/data/goal_src/engine/game/collectables.gc
@@ -144,6 +144,18 @@
   (none)
 )
 
+(defun advanceCheckpointList ((n int))
+  (define tempCount 0)
+  (dotimes (tempCount n)
+    (set! *next-rando-checkpoint-node* (cdr *next-rando-checkpoint-node*))
+
+    ;; if we're at end of list, reset pointer to head of list
+    (when (null? (car *next-rando-checkpoint-node*))
+      (set! *next-rando-checkpoint-node* *rando-checkpoint-list*)
+    )
+  )
+)
+
 (defun warpToCheckpoint ((checkpointName string))
   ;; warps to checkpoint, assuming it is already safe to use
   (format 0 "RANDOMIZER: ...warping to ~A~%" checkpointName)
@@ -170,7 +182,9 @@
     (when (null? (car *next-rando-checkpoint-node*))
       (set! *next-rando-checkpoint-node* *rando-checkpoint-list*)
     )
-    
+    ;; increment number of checkpoints used (intentionally includes any skipped citadel checkpoints)
+    (+! (-> *randomizer-settings* backup-checkpoints-used) 1)
+
     (if (checkRandomCheckpoint? (the-as string checkpointName))
       (begin 
         (format 0 "RANDOMIZER: checkpoint ~A is valid~%" checkpointName)
@@ -1915,9 +1929,20 @@
           (if (-> *randomizer-settings* use-random-seed?)
             (set! (-> *randomizer-settings* current-seed) (rand-vu-float-range 0.0 10.0))
           )
+          ;; reset checkpoint counter backup
+          (set! (-> *randomizer-settings* backup-checkpoints-used) 0)
 
           ;; generate checkpoint list from seed
           (generateCheckpointList (-> *randomizer-settings* current-seed))
+        )
+
+        ;; in case of crash/closed window/etc, generate from last seed and advance checkpoints
+        (when (null? (peekNextCheckpoint))
+          (format 0 "Regenerating checkpoint list from backup, checkpoints used: ~D~%" (-> *randomizer-settings* backup-checkpoints-used))
+
+          ;; generate checkpoint list from seed
+          (generateCheckpointList (-> *randomizer-settings* current-seed))
+          (advanceCheckpointList (-> *randomizer-settings* backup-checkpoints-used))
         )
         
         (set! *cell-interval* (+ *cell-interval* 1))
@@ -1929,6 +1954,9 @@
             (set! *cell-interval* 0.0)
           )
         )
+
+        ;; current-seed and backup-checkpoints-used are updated at this point, commit to file in case of crash/closed window
+        (commit-to-file *randomizer-settings*)
       )
     )
 

--- a/out/data/goal_src/engine/game/main.gc
+++ b/out/data/goal_src/engine/game/main.gc
@@ -134,7 +134,7 @@
                                        'target-flut-walk) #t))))
 
   ;;clean *stdcon*
-  (clear *stdcon*)  
+  (clear *stdcon*)
   (if (> (-> *game-info* fuel) 0)
     ;; Display the current seed
     (format *stdcon* " ~F~%"  (-> *randomizer-settings* current-seed))

--- a/out/data/goal_src/pc/pckernel-h.gc
+++ b/out/data/goal_src/pc/pckernel-h.gc
@@ -438,6 +438,7 @@
     (use-random-seed? symbol) ;; boolean (#t = random seed / #f = set seed)
     
     (current-seed float) ;; current seed for Bargs logic
+    (backup-checkpoints-used int) ;; backup in case of game crash
     ;; TODO - save/restore original settings (language/sound/etc)
     )
 
@@ -471,6 +472,7 @@
     (format file "  (Randomizer? ~A)~%" (-> obj checkpoint-randomizer?))
     (format file "  (use-random-seed? ~A)~%" (-> obj use-random-seed?))
     (format file "  (Seed ~F)~%" (-> obj current-seed))
+    (format file "  (backup-checkpoints-used ~D)~%" (-> obj backup-checkpoints-used))
 
     (format file "  )~%")
     (file-stream-close file)
@@ -549,6 +551,7 @@
   (set! (-> obj cells-needed-to-warp) 1.0)
   (set! (-> obj use-random-seed?) #t)
   (set! (-> obj current-seed) 432.32765492375)
+  (set! (-> obj backup-checkpoints-used) 0)
   (none))
 
  (deftype challenges-settings (basic)

--- a/out/data/goal_src/pc/pckernel.gc
+++ b/out/data/goal_src/pc/pckernel.gc
@@ -1087,6 +1087,7 @@
                 (("cells-needed-to-warp") (set! (-> obj cells-needed-to-warp) (file-stream-read-float file)))
                 (("use-random-seed?") (set! (-> obj use-random-seed?) (file-stream-read-symbol file)))
                 (("Seed") (set! (-> obj current-seed) (file-stream-read-float file)))
+                (("backup-checkpoints-used") (set! (-> obj backup-checkpoints-used) (file-stream-read-int file)))
                 )
               )
             )


### PR DESCRIPTION
Basically if we get into a state where the checkpoint list hasn't been generated, generate it from the backed up seed, and advance it by the backed up count of checkpoints used. The seed can only be modified manually or when collecting the first cell in a file (in random-seed), so it should be preserved in the case of a crash