### PR TITLE
More fixes

### DIFF
--- a/Checkpoint randomizer/data/goal_src/jak1/engine/common-obs/collectables.gc
+++ b/Checkpoint randomizer/data/goal_src/jak1/engine/common-obs/collectables.gc
@@ -804,7 +804,7 @@
         )
       )
      (begin
-        (orchestrateCheckpointWarp) 
+        (orchestrateCheckpointWarp 1)
       )
     )
     (if (nonzero? (-> self part))
@@ -1225,7 +1225,7 @@
           (-> *randomizer-settings* warp-on-orb?)
           (!= (-> money-parent type) orb-cache-top)
         )
-        (orchestrateCheckpointWarp)
+        (orchestrateCheckpointWarp 1)
       )
       (convert-to-hud-object self (the-as hud (ppointer->process (-> *hud-parts* money))))
       (none)
@@ -1742,7 +1742,7 @@
     
     ;; warp to random checkpoint if randomizer enabled
     (if (and (-> *randomizer-settings* checkpoint-randomizer?) (-> *randomizer-settings* warp-on-cell?))
-      (orchestrateCheckpointWarp)
+      (orchestrateCheckpointWarp 1)
     )
 
     (process-spawn-function
@@ -2360,7 +2360,7 @@
       )
     (if (and (-> *randomizer-settings* checkpoint-randomizer?) (-> *randomizer-settings* warp-on-buzzer?))
     (begin
-       (orchestrateCheckpointWarp) 
+       (orchestrateCheckpointWarp 1)
     )
     )
     (none)
@@ -2977,7 +2977,7 @@
         )
        )
       (begin
-        (orchestrateCheckpointWarp)
+        (orchestrateCheckpointWarp 1)
        )
       )
     (if (and (or (= arg2 'touch) (= arg2 'attack))

--- a/Checkpoint randomizer/data/goal_src/jak1/engine/common-obs/orb-cache.gc
+++ b/Checkpoint randomizer/data/goal_src/jak1/engine/common-obs/orb-cache.gc
@@ -19,11 +19,12 @@
    (root-pos          float     :offset-assert 1204)
    (money             int32     :offset-assert 1208)
    (activated         symbol    :offset-assert 1212)
+   (initial-money     int32     :offset-assert 1216)
    )
-  :heap-base #x450
+  :heap-base #x460
   :method-count-assert 29
-  :size-assert         #x4c0
-  :flag-assert         #x1d045004c0
+  :size-assert         #x4c4
+  :flag-assert         #x1d046004c4
   (:methods
     (pos-logic (_type_ symbol) symbol 27)
     (calculate-pos (_type_ symbol) none 28)
@@ -122,22 +123,35 @@
   )
 
 (defmethod pos-logic orb-cache-top ((obj orb-cache-top) (arg0 symbol))
-  (dotimes (s4-0 (-> obj money))
-    (when (not (handle->process (-> obj money-list s4-0)))
-      (dotimes (v1-6 (-> obj money))
-        (when (< s4-0 v1-6)
-          (set! (-> obj money-list (+ v1-6 -1)) (-> obj money-list v1-6))
-          (set! (-> obj money-pos-actual (+ v1-6 -1)) (-> obj money-pos-actual v1-6))
+  (let ((orbs-collected #f))
+    (dotimes (s4-0 (-> obj money))
+      (when (not (handle->process (-> obj money-list s4-0)))
+        (dotimes (v1-6 (-> obj money))
+          (when (< s4-0 v1-6)
+            (set! (-> obj money-list (+ v1-6 -1)) (-> obj money-list v1-6))
+            (set! (-> obj money-pos-actual (+ v1-6 -1)) (-> obj money-pos-actual v1-6))
+            )
+          )
+        (+! (-> obj money) -1)
+        (set! orbs-collected #t)
+        (calculate-pos obj arg0)
+        (+! s4-0 -1)
+        (let ((v1-15 (-> obj entity extra perm)))
+          (logior! (-> v1-15 status) (entity-perm-status user-set-from-cstage))
+          (+! (-> v1-15 user-int16 0) 1)
           )
         )
-      (+! (-> obj money) -1)
-      (calculate-pos obj arg0)
-      (+! s4-0 -1)
-      (let ((v1-15 (-> obj entity extra perm)))
-        (logior! (-> v1-15 status) (entity-perm-status user-set-from-cstage))
-        (+! (-> v1-15 user-int16 0) 1)
-        )
       )
+      ;; if we collected orbs and now there are no more, give credit for the total orbs in this cache
+      (when (and
+            orbs-collected
+            (zero? (-> obj money))
+            (-> *randomizer-settings* checkpoint-randomizer?)
+            (-> *randomizer-settings* warp-on-orb?)
+          )
+          (format 0 "RANDOMIZER: got ~D orbs from cache, checking warp~%" (-> obj initial-money))
+          (orchestrateCheckpointWarp (-> obj initial-money))
+        )
     )
   (let ((s4-1 (new 'stack-no-clear 'vector))
         (s5-1 #t)
@@ -227,14 +241,6 @@
                       )
                   )
         (pos-logic self #t)
-        ;; if the randomizer is on AND set to warp on orbs AND that was the last orb, warp the target.
-        (if (and 
-            (-> *randomizer-settings* checkpoint-randomizer?) 
-            (-> *randomizer-settings* warp-on-orb?)
-            (zero? (-> self money))
-          )
-          (orchestrateCheckpointWarp)
-        )
         (suspend)
         )
       (calculate-pos self #f)
@@ -347,6 +353,7 @@
     (logior! (-> v1-39 status) (entity-perm-status user-set-from-cstage))
     (set! (-> obj money) (- (-> obj money) (-> v1-39 user-int16 0)))
     )
+  (set! (-> obj initial-money) (-> obj money))
   (dotimes (v1-42 (-> obj money))
     (set! (-> obj money-list v1-42) (the-as handle #f))
     )

--- a/Checkpoint randomizer/data/goal_src/jak1/engine/common-obs/orb-cache.gc
+++ b/Checkpoint randomizer/data/goal_src/jak1/engine/common-obs/orb-cache.gc
@@ -123,7 +123,7 @@
   )
 
 (defmethod pos-logic orb-cache-top ((obj orb-cache-top) (arg0 symbol))
-  (let ((orbs-collected #f))
+  (let ((orbs-collected? #f))
     (dotimes (s4-0 (-> obj money))
       (when (not (handle->process (-> obj money-list s4-0)))
         (dotimes (v1-6 (-> obj money))
@@ -133,7 +133,7 @@
             )
           )
         (+! (-> obj money) -1)
-        (set! orbs-collected #t)
+        (set! orbs-collected? #t)
         (calculate-pos obj arg0)
         (+! s4-0 -1)
         (let ((v1-15 (-> obj entity extra perm)))
@@ -144,7 +144,7 @@
       )
       ;; if we collected orbs and now there are no more, give credit for the total orbs in this cache
       (when (and
-            orbs-collected
+            orbs-collected?
             (zero? (-> obj money))
             (-> *randomizer-settings* checkpoint-randomizer?)
             (-> *randomizer-settings* warp-on-orb?)

--- a/Checkpoint randomizer/data/goal_src/jak1/engine/game/game-info.gc
+++ b/Checkpoint randomizer/data/goal_src/jak1/engine/game/game-info.gc
@@ -163,7 +163,7 @@
   (-> obj task-perm-list data arg0)
   )
 
-(define-extern orchestrateCheckpointWarp (function none))
+(define-extern orchestrateCheckpointWarp (function int none))
 (defmethod initialize! game-info ((obj game-info) (cause symbol) (save-to-load game-save) (continue-point-override string))
   "Initialize the game-info.
     The cause can be 'dead if you die, or 'game to reset everything.
@@ -207,7 +207,7 @@
        )
      (if (and (-> *randomizer-settings* checkpoint-randomizer?) (-> *randomizer-settings* warp-on-death?))
       (begin
-        (orchestrateCheckpointWarp)
+        (orchestrateCheckpointWarp 1)
        )
       )
      )

--- a/Checkpoint randomizer/data/goal_src/jak1/engine/mods/checkpoint-randomizer.gc
+++ b/Checkpoint randomizer/data/goal_src/jak1/engine/mods/checkpoint-randomizer.gc
@@ -278,7 +278,7 @@
   (< (current-time) (-> *game-info* blackout-time))
 )
 
-(defun orchestrateCheckpointWarp ()
+(defun orchestrateCheckpointWarp ((amount int))
   ;; first collectable? need to generate checkpoint list
   (when (= *randomizer-items-collected* 1)
     ;; randomly generate or set seed
@@ -302,21 +302,21 @@
     (advanceCheckpointList (-> *randomizer-settings* backup-checkpoints-used))
   )
 
-  (set! *collectable-interval* (+ *collectable-interval* 1))
+  ;; if blacked out we're already warping, so skip (i.e. to handle orb crate case)
+  (if (not (blacked-out?))
+    (begin
+      (+! *collectable-interval* amount)
 
-  ;; if we're above the collectable threshold, then warp
-  (when (>= *collectable-interval* (-> *randomizer-settings* collectables-needed-to-warp))
-    ;; if blacked out we're already warping, so skip (i.e. to handle orb crate case)
-    (if (not (blacked-out?))
-      (begin
+      ;; if we're above the collectable threshold, then warp
+      (when (>= *collectable-interval* (-> *randomizer-settings* collectables-needed-to-warp))
         (format 0 "RANDOMIZER: warping from ~A...~%" (-> *level* level 0 name))
         (warpToCheckpoint (the-as string (getNextCheckpoint)))
-      )
-      (begin
-        (format 0 "RANDOMIZER: skipping warp as we're already blackout~%")
+        (set! *collectable-interval* 0.0)
       )
     )
-    (set! *collectable-interval* 0.0)
+    (begin
+      (format 0 "RANDOMIZER: skipping collectable/warp as we're already blackout. ~D ~D ~%" (current-time) (-> *game-info* blackout-time))
+    )
   )
 
   ;; current-seed and backup-checkpoints-used are updated at this point, commit to file in case of crash/closed window

--- a/Checkpoint randomizer/data/goal_src/jak1/engine/mods/checkpoint-randomizer.gc
+++ b/Checkpoint randomizer/data/goal_src/jak1/engine/mods/checkpoint-randomizer.gc
@@ -302,7 +302,7 @@
     (advanceCheckpointList (-> *randomizer-settings* backup-checkpoints-used))
   )
 
-  ;; if blacked out we're already warping, so skip (i.e. to handle orb crate case)
+  ;; if blacked out we're already warping, so skip
   (if (not (blacked-out?))
     (begin
       (+! *collectable-interval* amount)

--- a/Checkpoint randomizer/data/goal_src/jak1/engine/target/target-death.gc
+++ b/Checkpoint randomizer/data/goal_src/jak1/engine/target/target-death.gc
@@ -1358,6 +1358,11 @@
            (sound-play "death-drown")
            )
           )
+        (if (and (-> *randomizer-settings* checkpoint-randomizer?) (-> *randomizer-settings* warp-on-death?))
+          (begin
+            (orchestrateCheckpointWarp 1)
+            )
+          )
         (+! (-> *game-info* death-movie-tick) 1)
         (if (= (death-movie-remap (+ (-> *game-info* death-movie-tick) -1) (-> *death-spool-array* length))
                (death-movie-remap (-> *game-info* death-movie-tick) (-> *death-spool-array* length))


### PR DESCRIPTION
Easier to read the diff with whitespace hidden - https://github.com/Zedb0T/OpenGoal-CheckpointRandomizer/pull/88/files?diff=split&w=1

- fix no warp when you die with dax cutscene. 
- fix collectable-interval logic. 
- fix orb vent collectable count bug 
  - previously it would count towards collectable-interval every frame you left the cache open and there were no orbs remaining in it, so if you got stuck underneath it just kept increasing indefinitely
  - now it just gives you credit for the total number of orbs only once, exactly when it finally decrements the remaining orb count to 0